### PR TITLE
Stop mrp app before shutting down

### DIFF
--- a/cmd/firehose-tendermint/app_ingestor.go
+++ b/cmd/firehose-tendermint/app_ingestor.go
@@ -53,6 +53,7 @@ func init() {
 		flags.String("ingestor-node-dir", "", "Node working directory")
 		flags.String("ingestor-node-args", "", "Node process arguments")
 		flags.String("ingestor-node-env", "", "Node process env vars")
+		flags.Duration("ingestor-wait-upload-complete-on-shutdown", 10*time.Second, "When the ingestor is shutting down, it will wait up to that amount of time for the archiver to finish uploading the blocks before leaving anyway")
 
 		return nil
 	}

--- a/cmd/firehose-tendermint/ingestor.go
+++ b/cmd/firehose-tendermint/ingestor.go
@@ -47,6 +47,7 @@ func (app *IngestorApp) Run() error {
 	app.OnTerminating(func(err error) {
 		cancel()
 	})
+
 	app.mrp.OnTerminated(func(err error) {
 		app.Shutdown(err)
 	})
@@ -73,6 +74,7 @@ func (app *IngestorApp) Run() error {
 		}
 
 		zlog.Info("event logs reader finished", zap.Error(err))
+		app.mrp.Stop()
 		app.mrp.Shutdown(err)
 	}()
 


### PR DESCRIPTION
- calling `mrp.Shutdown` will cause it to abort without waiting for any in-flight operations
- CLI option `ingestor-wait-upload-complete-on-shutdown` was not utilized, always being set to 0