### PR TITLE
Node log stream filtering

### DIFF
--- a/cmd/firehose-tendermint/app_ingestor.go
+++ b/cmd/firehose-tendermint/app_ingestor.go
@@ -53,6 +53,7 @@ func init() {
 		flags.String("ingestor-node-dir", "", "Node working directory")
 		flags.String("ingestor-node-args", "", "Node process arguments")
 		flags.String("ingestor-node-env", "", "Node process env vars")
+		flags.String("ingestor-node-filter", "", "Node process log filter expression")
 		flags.Duration("ingestor-wait-upload-complete-on-shutdown", 10*time.Second, "When the ingestor is shutting down, it will wait up to that amount of time for the archiver to finish uploading the blocks before leaving anyway")
 
 		return nil
@@ -147,6 +148,7 @@ func init() {
 			nodeDir:          viper.GetString("ingestor-node-dir"),
 			nodeArgs:         viper.GetString("ingestor-node-args"),
 			nodeEnv:          viper.GetString("ingestor-node-env"),
+			nodeLogsFilter:   viper.GetString("ingestor-node-filter"),
 			logsDir:          viper.GetString("ingestor-logs-dir"),
 			logsFilePattern:  viper.GetString("ingestor-logs-pattern"),
 			server:           server,

--- a/cmd/firehose-tendermint/app_ingestor.go
+++ b/cmd/firehose-tendermint/app_ingestor.go
@@ -53,7 +53,7 @@ func init() {
 		flags.String("ingestor-node-dir", "", "Node working directory")
 		flags.String("ingestor-node-args", "", "Node process arguments")
 		flags.String("ingestor-node-env", "", "Node process env vars")
-		flags.String("ingestor-node-filter", "", "Node process log filter expression")
+		flags.String("ingestor-node-logs-filter", "", "Node process log filter expression")
 		flags.Duration("ingestor-wait-upload-complete-on-shutdown", 10*time.Second, "When the ingestor is shutting down, it will wait up to that amount of time for the archiver to finish uploading the blocks before leaving anyway")
 
 		return nil
@@ -148,7 +148,7 @@ func init() {
 			nodeDir:          viper.GetString("ingestor-node-dir"),
 			nodeArgs:         viper.GetString("ingestor-node-args"),
 			nodeEnv:          viper.GetString("ingestor-node-env"),
-			nodeLogsFilter:   viper.GetString("ingestor-node-filter"),
+			nodeLogsFilter:   viper.GetString("ingestor-node-logs-filter"),
 			logsDir:          viper.GetString("ingestor-logs-dir"),
 			logsFilePattern:  viper.GetString("ingestor-logs-pattern"),
 			server:           server,

--- a/cmd/firehose-tendermint/ingestor.go
+++ b/cmd/firehose-tendermint/ingestor.go
@@ -25,10 +25,11 @@ type IngestorApp struct {
 	server           *dgrpc.Server
 
 	// Node runner options
-	nodeBinPath string
-	nodeDir     string
-	nodeArgs    string
-	nodeEnv     string
+	nodeBinPath    string
+	nodeDir        string
+	nodeArgs       string
+	nodeEnv        string
+	nodeLogsFilter string
 
 	// Log reader options
 	logsDir         string
@@ -102,6 +103,7 @@ func (app *IngestorApp) startFromNode(ctx context.Context) error {
 	runner.SetLineReader(app.mrp.LogLine)
 	runner.SetDir(app.nodeDir)
 	runner.SetEnv(env)
+	runner.SetLogFiltering(app.nodeLogsFilter)
 
 	return runner.Start(ctx)
 }

--- a/noderunner/filtered_writer.go
+++ b/noderunner/filtered_writer.go
@@ -10,12 +10,6 @@ type FilteredWriter struct {
 	dst io.Writer
 }
 
-const (
-	// Regular expression to filter out unwanted logs
-	// NOTE: these wont work when node process runs without "--log_format=json" CLI arg
-	exampleFilterExpr = `"module":"(p2p|pex|consensus|x\/bank)"`
-)
-
 var (
 	decolorizeRe = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
 )

--- a/noderunner/filtered_writer.go
+++ b/noderunner/filtered_writer.go
@@ -29,6 +29,5 @@ func (w FilteredWriter) Write(data []byte) (int, error) {
 		return len(data), nil
 	}
 
-	_, err := w.dst.Write(clean)
-	return len(data), err
+	return w.dst.Write(data)
 }

--- a/noderunner/filtered_writer.go
+++ b/noderunner/filtered_writer.go
@@ -1,0 +1,23 @@
+package noderunner
+
+import (
+	"io"
+	"regexp"
+)
+
+type FilteredWriter struct {
+	Writer io.Writer
+}
+
+var (
+	// Regular expression to filter out unwanted logs
+	// NOTE: these wont work when node process runs without "--log_format=json" CLI arg
+	ignoreRegex = regexp.MustCompile(`"module":"(p2p|pex|consensus|x\/bank)"`)
+)
+
+func (w FilteredWriter) Write(data []byte) (int, error) {
+	if ignoreRegex.Match(data) {
+		return len(data), nil
+	}
+	return w.Writer.Write(data)
+}

--- a/noderunner/filtered_writer_test.go
+++ b/noderunner/filtered_writer_test.go
@@ -31,6 +31,13 @@ func TestFilteredWriter(t *testing.T) {
 			},
 			output: "Doing something",
 		},
+		{
+			expr: "deepmind",
+			input: []string{
+				"\x1b[90m1:01PM\x1b[0m \x1b[32mINF\x1b[0m Version info \x1b[36mblock=\x1b[0m11 \x1b[36mp2p=\x1b[0m8 \x1b[36msoftware=\x1b[0mv0.34.9-deepmind\n",
+			},
+			output: "",
+		},
 	}
 
 	for _, ex := range examples {

--- a/noderunner/filtered_writer_test.go
+++ b/noderunner/filtered_writer_test.go
@@ -1,0 +1,49 @@
+package noderunner
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilteredWriter(t *testing.T) {
+	examples := []struct {
+		expr   string
+		input  []string
+		output string
+	}{
+		{
+			expr: "foo",
+			input: []string{
+				"foo",
+				"bar",
+			},
+			output: "bar",
+		},
+		{
+			expr: `\smodule=(p2p|pex|consensus|x\/bank)`,
+			input: []string{
+				`ERR error while stopping peer error="already stopped" module=p2p`,
+				`INF Stopping BlockPool service impl={"Logger":{}} module=pex`,
+				`Doing something`,
+				`ERR error while stopping peer error="already stopped" module=consensus`,
+			},
+			output: "Doing something",
+		},
+	}
+
+	for _, ex := range examples {
+		out := bytes.NewBuffer(nil)
+
+		writer, err := NewFilteredWriter(out, ex.expr)
+		assert.NoError(t, err)
+
+		for _, line := range ex.input {
+			_, err := writer.Write([]byte(line))
+			assert.NoError(t, err)
+		}
+
+		assert.Equal(t, ex.output, out.String())
+	}
+}

--- a/noderunner/node_runner.go
+++ b/noderunner/node_runner.go
@@ -30,6 +30,8 @@ type NodeRunner struct {
 	forcedKillTimeout time.Duration
 	logger            *zap.Logger
 	done              chan struct{}
+	logFilter         bool
+	logFilterExpr     string
 }
 
 func New(bin string, args []string, stderr bool) *NodeRunner {
@@ -64,6 +66,12 @@ func (runner *NodeRunner) SetDir(dir string) {
 	runner.dir = dir
 }
 
+func (runner *NodeRunner) SetLogFiltering(expr string) {
+	if expr != "" {
+		runner.logFilterExpr = expr
+	}
+}
+
 func (runner *NodeRunner) Start(ctx context.Context) error {
 	if runner.bin == "" {
 		return errors.New("binary path is not provided")
@@ -90,7 +98,15 @@ func (runner *NodeRunner) startProcess(ctx context.Context) error {
 	}
 
 	if runner.stderr {
-		cmd.Stderr = FilteredWriter{Writer: os.Stderr}
+		cmd.Stderr = os.Stderr
+
+		if runner.logFilterExpr != "" {
+			filterWriter, err := NewFilteredWriter(cmd.Stderr, runner.logFilterExpr)
+			if err != nil {
+				return err
+			}
+			cmd.Stderr = filterWriter
+		}
 	}
 
 	cmdStdout, err := cmd.StdoutPipe()

--- a/noderunner/node_runner.go
+++ b/noderunner/node_runner.go
@@ -83,8 +83,6 @@ func (runner *NodeRunner) Start(ctx context.Context) error {
 
 func (runner *NodeRunner) startProcess(ctx context.Context) error {
 	cmd := exec.Command(runner.bin, runner.args...)
-	cmd.Stdin = nil
-	cmd.Stderr = nil
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if len(runner.env) > 0 {

--- a/noderunner/node_runner.go
+++ b/noderunner/node_runner.go
@@ -90,7 +90,7 @@ func (runner *NodeRunner) startProcess(ctx context.Context) error {
 	}
 
 	if runner.stderr {
-		cmd.Stderr = os.Stderr
+		cmd.Stderr = FilteredWriter{Writer: os.Stderr}
 	}
 
 	cmdStdout, err := cmd.StdoutPipe()

--- a/noderunner/node_runner.go
+++ b/noderunner/node_runner.go
@@ -83,6 +83,7 @@ func (runner *NodeRunner) Start(ctx context.Context) error {
 
 func (runner *NodeRunner) startProcess(ctx context.Context) error {
 	cmd := exec.Command(runner.bin, runner.args...)
+	cmd.Stdin = nil
 	cmd.Stderr = nil
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 


### PR DESCRIPTION
This PR adds support for filtering of the logs coming from the node when ingestor is running in the `node` mode. 
It seems like there's no way to turn off colorization of the logs in the node via CLI flags, so we try to do it in the ingestor. Volume of the logs is low enough to not have any performance hit on the processing. 