### PR TITLE
Add option to turn off bstream addr

### DIFF
--- a/cmd/firehose-tendermint/app_firehose.go
+++ b/cmd/firehose-tendermint/app_firehose.go
@@ -46,7 +46,7 @@ func init() {
 
 		// Configure block stream connection (to node or relayer)
 		blockstreamAddr := viper.GetString("common-blockstream-addr")
-		if blockstreamAddr != "" {
+		if blockstreamAddr != "" && blockstreamAddr != "-" {
 			tracker.AddGetter(bstream.BlockStreamLIBTarget, bstream.StreamLIBBlockRefGetter(blockstreamAddr))
 			tracker.AddGetter(bstream.BlockStreamHeadTarget, bstream.StreamHeadBlockRefGetter(blockstreamAddr))
 		}


### PR DESCRIPTION
Simply changing the bstream addr to `-` will allow running firehose using only merged blocks data. Disabling bstream addr via empty arg causes firehose to use the default `localhost:9000` address.